### PR TITLE
feat: add skeleton react ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# hdpui
+# Hybrid Data Platform UI
+
+A minimal React UI providing:
+
+- Dataset search
+- Tenant onboarding for applications
+- Dataset access requests
+- Chatbot helper
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Run tests (none configured):
+
+```bash
+npm test
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hybrid Data Platform UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "hdpui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests implemented'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.2.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import DatasetSearch from './components/DatasetSearch';
+import TenantOnboarding from './components/TenantOnboarding';
+import DatasetAccessRequest from './components/DatasetAccessRequest';
+import Chatbot from './components/Chatbot';
+
+type View = 'search' | 'onboard' | 'access' | 'chat';
+
+const App: React.FC = () => {
+  const [view, setView] = useState<View>('search');
+
+  return (
+    <>
+      <nav>
+        <button onClick={() => setView('search')}>Search Datasets</button>
+        <button onClick={() => setView('onboard')}>Onboard App</button>
+        <button onClick={() => setView('access')}>Request Access</button>
+        <button onClick={() => setView('chat')}>Chatbot</button>
+      </nav>
+      <main>
+        {view === 'search' && <DatasetSearch />}
+        {view === 'onboard' && <TenantOnboarding />}
+        {view === 'access' && <DatasetAccessRequest />}
+        {view === 'chat' && <Chatbot />}
+      </main>
+    </>
+  );
+};
+
+export default App;

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+interface Message {
+  from: 'user' | 'bot';
+  text: string;
+}
+
+const Chatbot: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = () => {
+    if (!input) return;
+    setMessages([...messages, { from: 'user', text: input }, { from: 'bot', text: 'This is a placeholder response.' }]);
+    setInput('');
+  };
+
+  return (
+    <div>
+      <h2>Chatbot</h2>
+      <div>
+        {messages.map((m, i) => (
+          <p key={i}><strong>{m.from}:</strong> {m.text}</p>
+        ))}
+      </div>
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="Type a message"
+      />
+      <button onClick={sendMessage} className="primary">Send</button>
+    </div>
+  );
+};
+
+export default Chatbot;

--- a/src/components/DatasetAccessRequest.tsx
+++ b/src/components/DatasetAccessRequest.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+const DatasetAccessRequest: React.FC = () => {
+  const [form, setForm] = useState({
+    dataset: '',
+    legalEntity: '',
+    purpose: '',
+    duration: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert('Access request submitted');
+  };
+
+  return (
+    <div>
+      <h2>Request Dataset Access</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          name="dataset"
+          placeholder="Dataset name"
+          value={form.dataset}
+          onChange={handleChange}
+        />
+        <input
+          name="legalEntity"
+          placeholder="Controlling Legal Entity"
+          value={form.legalEntity}
+          onChange={handleChange}
+        />
+        <input
+          name="purpose"
+          placeholder="Purpose"
+          value={form.purpose}
+          onChange={handleChange}
+        />
+        <input
+          name="duration"
+          placeholder="Duration"
+          value={form.duration}
+          onChange={handleChange}
+        />
+        <button type="submit" className="primary">Submit</button>
+      </form>
+    </div>
+  );
+};
+
+export default DatasetAccessRequest;

--- a/src/components/DatasetSearch.tsx
+++ b/src/components/DatasetSearch.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+
+const datasets = ['CustomerProfiles', 'SalesData', 'Inventory', 'Marketing'];
+
+const DatasetSearch: React.FC = () => {
+  const [query, setQuery] = useState('');
+
+  const results = datasets.filter((d) =>
+    d.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div>
+      <h2>Search Datasets</h2>
+      <input
+        placeholder="Search..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <ul>
+        {results.map((r) => (
+          <li key={r}>{r}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DatasetSearch;

--- a/src/components/TenantOnboarding.tsx
+++ b/src/components/TenantOnboarding.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+
+const TenantOnboarding: React.FC = () => {
+  const [form, setForm] = useState({
+    applicationId: '',
+    services: '',
+    acl: '',
+    legalEntity: '',
+    visibility: 'private',
+    useCases: '',
+    permissions: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert('Onboarding request submitted');
+  };
+
+  return (
+    <div>
+      <h2>Onboard Application</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          name="applicationId"
+          placeholder="Application ID (NAR ID)"
+          value={form.applicationId}
+          onChange={handleChange}
+        />
+        <input
+          name="services"
+          placeholder="Services Required"
+          value={form.services}
+          onChange={handleChange}
+        />
+        <input
+          name="acl"
+          placeholder="Developer ACL"
+          value={form.acl}
+          onChange={handleChange}
+        />
+        <input
+          name="legalEntity"
+          placeholder="Controlling Legal Entity"
+          value={form.legalEntity}
+          onChange={handleChange}
+        />
+        <select name="visibility" value={form.visibility} onChange={handleChange}>
+          <option value="private">Private</option>
+          <option value="published">Published</option>
+        </select>
+        {form.visibility === 'published' && (
+          <input
+            name="useCases"
+            placeholder="Use Cases"
+            value={form.useCases}
+            onChange={handleChange}
+          />
+        )}
+        <textarea
+          name="permissions"
+          placeholder="Permissions / OPA policies"
+          value={form.permissions}
+          onChange={handleChange}
+        />
+        <button type="submit" className="primary">Submit</button>
+      </form>
+    </div>
+  );
+};
+
+export default TenantOnboarding;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,44 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #f5f5f5;
+}
+
+nav {
+  background-color: #282c34;
+  color: white;
+  padding: 1rem;
+  display: flex;
+  gap: 1rem;
+}
+
+nav button {
+  background: none;
+  color: inherit;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+main {
+  padding: 1rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 600px;
+}
+
+input, textarea, select {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+button.primary {
+  background-color: #61dafb;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add Vite-based React setup for Hybrid Data Platform
- implement dataset search, application onboarding, dataset access request, and chatbot components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06bf5896c832481d638590a0b342c