### PR TITLE
feat: add themed react query app skeleton with tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': 'identity-obj-proxy'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo 'No tests implemented'"
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -15,7 +15,8 @@
     "styled-components": "^5.3.11",
     "react-hook-form": "^7.49.2",
     "@hookform/resolvers": "^3.3.4",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@tanstack/react-query": "^4.35.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
@@ -23,6 +24,13 @@
     "@types/react-dom": "^18.2.0",
     "@types/styled-components": "^5.1.26",
     "vite": "^5.0.0",
-    "@vitejs/plugin-react": "^4.2.0"
+    "@vitejs/plugin-react": "^4.2.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { ThemeProvider } from 'styled-components';
 import { Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
@@ -7,6 +7,9 @@ import Chatbot from './components/Chatbot';
 import DatasetSearch from './pages/DatasetSearch';
 import TenantOnboarding from './pages/TenantOnboarding';
 import DatasetAccessRequest from './pages/DatasetAccessRequest';
+import DatasetDetail from './pages/DatasetDetail';
+import { GlobalStyle } from './globalStyles';
+import { lightTheme, darkTheme } from './theme';
 
 const Layout = styled.div`
   display: grid;
@@ -27,20 +30,25 @@ const Main = styled.main`
 
 const App: React.FC = () => {
   const [chatOpen, setChatOpen] = useState(false);
+  const [dark, setDark] = useState(false);
 
   return (
-    <Layout>
-      <Header onToggleChat={() => setChatOpen(o => !o)} />
-      <Sidebar />
-      <Main>
-        <Routes>
-          <Route path="/" element={<DatasetSearch />} />
-          <Route path="/onboarding" element={<TenantOnboarding />} />
-          <Route path="/access" element={<DatasetAccessRequest />} />
-        </Routes>
-      </Main>
-      <Chatbot open={chatOpen} onClose={() => setChatOpen(false)} />
-    </Layout>
+    <ThemeProvider theme={dark ? darkTheme : lightTheme}>
+      <GlobalStyle />
+      <Layout>
+        <Header onToggleChat={() => setChatOpen(o => !o)} onToggleTheme={() => setDark(d => !d)} />
+        <Sidebar />
+        <Main>
+          <Routes>
+            <Route path="/" element={<DatasetSearch />} />
+            <Route path="/dataset/:id" element={<DatasetDetail />} />
+            <Route path="/onboarding" element={<TenantOnboarding />} />
+            <Route path="/access" element={<DatasetAccessRequest />} />
+          </Routes>
+        </Main>
+        <Chatbot open={chatOpen} onClose={() => setChatOpen(false)} />
+      </Layout>
+    </ThemeProvider>
   );
 };
 

--- a/src/__tests__/accessRequest.test.tsx
+++ b/src/__tests__/accessRequest.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DatasetAccessRequest from '../pages/DatasetAccessRequest';
+import { renderWithProviders } from '../tests/testUtils';
+
+test('submits access request and lists it', async () => {
+  renderWithProviders(<DatasetAccessRequest />);
+  const datasetSelect = await screen.findByLabelText(/Dataset\(s\)/i);
+  await userEvent.selectOptions(datasetSelect, ['1']);
+  await userEvent.type(screen.getByLabelText(/Controlling Legal Entity/i), 'DB AG');
+  await userEvent.type(screen.getByLabelText(/Purpose/i), 'testing');
+  await userEvent.type(screen.getByLabelText(/Start Date/i), '2024-01-01');
+  await userEvent.type(screen.getByLabelText(/End Date/i), '2024-02-01');
+  await userEvent.click(screen.getByText(/Request Access/i));
+  expect(await screen.findByText(/testing - pending/i)).toBeInTheDocument();
+});

--- a/src/__tests__/chatbot.test.tsx
+++ b/src/__tests__/chatbot.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Chatbot from '../components/Chatbot';
+import { renderWithProviders } from '../tests/testUtils';
+
+jest.mock('../services/chatApi', () => ({
+  sendMessage: async (text: string) => `You said: ${text}`
+}));
+
+test('chatbot sends and displays message', async () => {
+  renderWithProviders(<Chatbot open onClose={() => {}} />);
+  await userEvent.type(screen.getByLabelText(/Message/i), 'hello');
+  await userEvent.click(screen.getByText(/Send/i));
+  expect(await screen.findByText('You said: hello')).toBeInTheDocument();
+});

--- a/src/__tests__/datasetSearch.test.tsx
+++ b/src/__tests__/datasetSearch.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DatasetSearch from '../pages/DatasetSearch';
+import { renderWithProviders } from '../tests/testUtils';
+
+test('filters datasets by search input', async () => {
+  renderWithProviders(<DatasetSearch />);
+  const searchBox = await screen.findByLabelText(/search/i);
+  await userEvent.type(searchBox, 'Trades');
+  expect(await screen.findByText('Trades')).toBeInTheDocument();
+  expect(screen.queryByText('Payments')).not.toBeInTheDocument();
+});

--- a/src/__tests__/onboardingWizard.test.tsx
+++ b/src/__tests__/onboardingWizard.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TenantOnboarding from '../pages/TenantOnboarding';
+import { renderWithProviders } from '../tests/testUtils';
+
+test('progresses through onboarding steps', async () => {
+  renderWithProviders(<TenantOnboarding />);
+  await userEvent.type(screen.getByLabelText(/Application ID/i), 'app1');
+  await userEvent.type(screen.getByLabelText(/Application Name/i), 'My App');
+  await userEvent.click(screen.getByText(/next/i));
+  expect(await screen.findByText(/Services Required/i)).toBeInTheDocument();
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 interface Props {
   onToggleChat: () => void;
+  onToggleTheme: () => void;
 }
 
 const Bar = styled.header`
@@ -28,10 +29,13 @@ const ChatButton = styled.button`
   cursor: pointer;
 `;
 
-const Header: React.FC<Props> = ({ onToggleChat }) => (
+const Header: React.FC<Props> = ({ onToggleChat, onToggleTheme }) => (
   <Bar>
     <Title>Hybrid Data Platform</Title>
-    <ChatButton onClick={onToggleChat} aria-label="Toggle chatbot">Chat</ChatButton>
+    <div style={{ display: 'flex', gap: '0.5rem' }}>
+      <ChatButton onClick={onToggleTheme} aria-label="Toggle theme">🌓</ChatButton>
+      <ChatButton onClick={onToggleChat} aria-label="Toggle chatbot">Chat</ChatButton>
+    </div>
   </Bar>
 );
 

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -17,6 +17,7 @@ interface Props {
   onPageChange: (page: number) => void;
   sortField: keyof Dataset;
   onSort: (field: keyof Dataset) => void;
+  onRowClick?: (dataset: Dataset) => void;
 }
 
 const Table = styled.table`
@@ -33,7 +34,7 @@ const Pagination = styled.div`
   margin-top: 1rem;
 `;
 
-const SearchResults: React.FC<Props> = ({ data, page, pageSize, onPageChange, sortField, onSort }) => {
+const SearchResults: React.FC<Props> = ({ data, page, pageSize, onPageChange, sortField, onSort, onRowClick }) => {
   const start = page * pageSize;
   const paginated = data.slice(start, start + pageSize);
   const pages = Math.ceil(data.length / pageSize);
@@ -52,7 +53,7 @@ const SearchResults: React.FC<Props> = ({ data, page, pageSize, onPageChange, so
         </thead>
         <tbody>
           {paginated.map(ds => (
-            <tr key={ds.id}>
+            <tr key={ds.id} onClick={() => onRowClick?.(ds)} style={{ cursor: onRowClick ? 'pointer' : 'default' }}>
               <td>{ds.name}</td>
               <td>{ds.status}</td>
               <td>{ds.owner}</td>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { ThemeProvider } from 'styled-components';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
-import theme from './theme';
-import { GlobalStyle } from './globalStyles';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
+    <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <App />
       </BrowserRouter>
-    </ThemeProvider>
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/pages/DatasetDetail.tsx
+++ b/src/pages/DatasetDetail.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Dataset, fetchDatasets } from '../services/datasetService';
+
+const tabs = ['Overview', 'Permissions', 'Lineage', 'Usage'] as const;
+
+const DatasetDetail: React.FC = () => {
+  const { id } = useParams();
+  const { data: datasets = [] } = useQuery<Dataset[]>({ queryKey: ['datasets'], queryFn: fetchDatasets });
+  const dataset = datasets.find(d => d.id === Number(id));
+  const [tab, setTab] = useState<typeof tabs[number]>('Overview');
+
+  if (!dataset) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <Link to="/">← Back to search</Link>
+      <h2>{dataset.name}</h2>
+      <div role="tablist" style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        {tabs.map(t => (
+          <button
+            key={t}
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div>
+        {tab === 'Overview' && <pre>{JSON.stringify(dataset, null, 2)}</pre>}
+        {tab === 'Permissions' && <div>Permissions coming soon...</div>}
+        {tab === 'Lineage' && <div>Lineage coming soon...</div>}
+        {tab === 'Usage' && <div>Usage coming soon...</div>}
+      </div>
+    </div>
+  );
+};
+
+export default DatasetDetail;

--- a/src/pages/DatasetSearch.tsx
+++ b/src/pages/DatasetSearch.tsx
@@ -1,18 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import SearchResults from '../components/SearchResults';
 import { Dataset, fetchDatasets } from '../services/datasetService';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 const DatasetSearch: React.FC = () => {
-  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const navigate = useNavigate();
+  const { data: datasets = [] } = useQuery<Dataset[]>({ queryKey: ['datasets'], queryFn: fetchDatasets });
   const [query, setQuery] = useState('');
   const [status, setStatus] = useState('');
   const [tag, setTag] = useState('');
   const [page, setPage] = useState(0);
   const [sortField, setSortField] = useState<keyof Dataset>('name');
-
-  useEffect(() => {
-    fetchDatasets().then(setDatasets);
-  }, []);
 
   const tags = Array.from(new Set(datasets.flatMap(d => d.tags)));
 
@@ -59,6 +58,7 @@ const DatasetSearch: React.FC = () => {
         onPageChange={setPage}
         sortField={sortField}
         onSort={setSortField}
+        onRowClick={ds => navigate(`/dataset/${ds.id}`)}
       />
     </div>
   );

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/tests/testUtils.tsx
+++ b/src/tests/testUtils.tsx
@@ -1,0 +1,17 @@
+import React, { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '../theme';
+
+export const renderWithProviders = (ui: ReactNode) => {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <ThemeProvider theme={lightTheme}>{ui}</ThemeProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+};

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,9 +1,9 @@
 import { DefaultTheme } from 'styled-components';
 
-const theme: DefaultTheme = {
+export const lightTheme: DefaultTheme = {
   colors: {
-    primary: '#0018A8', // deep trust-evoking blue
-    accent: '#00A3E0', // bright accent blue
+    primary: '#0018A8',
+    accent: '#00A3E0',
     background: '#f5f7fa',
     text: '#000',
     white: '#ffffff'
@@ -11,4 +11,13 @@ const theme: DefaultTheme = {
   font: '"Helvetica Neue", Helvetica, Arial, sans-serif'
 };
 
-export default theme;
+export const darkTheme: DefaultTheme = {
+  colors: {
+    primary: '#0a0a0a',
+    accent: '#00A3E0',
+    background: '#1e1e1e',
+    text: '#fff',
+    white: '#2c2c2c'
+  },
+  font: '"Helvetica Neue", Helvetica, Arial, sans-serif'
+};


### PR DESCRIPTION
## Summary
- integrate React Query and dark/light theme toggle
- add dataset detail page and navigation hooks
- set up Jest testing with examples for search, wizard, access request, chatbot

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b074fe0e688324980bb1d5ef4ca465