### PR TITLE
feat: enhance dataset detail with ACLs and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log*
+coverage
+/dist
+.tmp
+.DS_Store

--- a/src/__tests__/datasetDetail.test.tsx
+++ b/src/__tests__/datasetDetail.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import DatasetDetail from '../pages/DatasetDetail';
+import { lightTheme } from '../theme';
+
+const renderPage = () => {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/dataset/1']}>
+        <ThemeProvider theme={lightTheme}>
+          <Routes>
+            <Route path="/dataset/:id" element={<DatasetDetail />} />
+          </Routes>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+test('allows editing tags and permissions', async () => {
+  const { findByText, getByRole, getByLabelText } = renderPage();
+
+  expect(await findByText('Payments')).toBeInTheDocument();
+
+  // add tag
+  await userEvent.type(getByLabelText('New tag'), 'urgent');
+  await userEvent.click(getByRole('button', { name: /add tag/i }));
+  expect(await findByText('urgent')).toBeInTheDocument();
+
+  // permissions tab
+  await userEvent.click(getByRole('tab', { name: /permissions/i }));
+  expect(await findByText('alice@example.com')).toBeInTheDocument();
+  await userEvent.type(getByLabelText('ACL user'), 'new@example.com');
+  await userEvent.type(getByLabelText('ACL role'), 'reader');
+  await userEvent.click(getByRole('button', { name: /^add$/i }));
+  expect(await findByText('new@example.com')).toBeInTheDocument();
+});

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-
-interface Dataset {
-  id: number;
-  name: string;
-  status: string;
-  owner: string;
-  tags: string[];
-  useCases: string[];
-}
+import { Dataset } from '../services/datasetService';
 
 interface Props {
   data: Dataset[];

--- a/src/pages/DatasetDetail.tsx
+++ b/src/pages/DatasetDetail.tsx
@@ -1,17 +1,58 @@
 import React, { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { Dataset, fetchDatasets } from '../services/datasetService';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  Dataset,
+  fetchDatasetById,
+  updateDataset,
+  AclEntry
+} from '../services/datasetService';
 
 const tabs = ['Overview', 'Permissions', 'Lineage', 'Usage'] as const;
 
 const DatasetDetail: React.FC = () => {
   const { id } = useParams();
-  const { data: datasets = [] } = useQuery<Dataset[]>({ queryKey: ['datasets'], queryFn: fetchDatasets });
-  const dataset = datasets.find(d => d.id === Number(id));
+  const datasetId = Number(id);
+  const queryClient = useQueryClient();
+
+  const { data: dataset } = useQuery<Dataset | undefined>({
+    queryKey: ['dataset', datasetId],
+    queryFn: () => fetchDatasetById(datasetId)
+  });
+
+  const mutation = useMutation({
+    mutationFn: (updates: Partial<Dataset>) => updateDataset(datasetId, updates),
+    onSuccess: data => {
+      queryClient.setQueryData(['dataset', datasetId], data);
+    }
+  });
+
   const [tab, setTab] = useState<typeof tabs[number]>('Overview');
 
+  const [newTag, setNewTag] = useState('');
+  const [acl, setAcl] = useState<AclEntry>({ user: '', role: '' });
+
   if (!dataset) return <div>Loading...</div>;
+
+  const toggleStatus = () => {
+    mutation.mutate({ status: dataset.status === 'published' ? 'private' : 'published' });
+  };
+
+  const addTag = () => {
+    if (!newTag.trim()) return;
+    mutation.mutate({ tags: [...dataset.tags, newTag.trim()] });
+    setNewTag('');
+  };
+
+  const removeTag = (t: string) => {
+    mutation.mutate({ tags: dataset.tags.filter(tag => tag !== t) });
+  };
+
+  const addAcl = () => {
+    if (!acl.user || !acl.role) return;
+    mutation.mutate({ acls: [...dataset.acls, acl] });
+    setAcl({ user: '', role: '' });
+  };
 
   return (
     <div>
@@ -30,10 +71,94 @@ const DatasetDetail: React.FC = () => {
         ))}
       </div>
       <div>
-        {tab === 'Overview' && <pre>{JSON.stringify(dataset, null, 2)}</pre>}
-        {tab === 'Permissions' && <div>Permissions coming soon...</div>}
-        {tab === 'Lineage' && <div>Lineage coming soon...</div>}
-        {tab === 'Usage' && <div>Usage coming soon...</div>}
+        {tab === 'Overview' && (
+          <div>
+            <p>{dataset.description}</p>
+            <div>
+              Visibility: {dataset.status}
+              <button onClick={toggleStatus} aria-label="Toggle visibility">
+                {dataset.status === 'published' ? 'Mark Private' : 'Publish'}
+              </button>
+            </div>
+            <div>
+              Tags:
+              <ul>
+                {dataset.tags.map(t => (
+                  <li key={t}>
+                    {t} <button onClick={() => removeTag(t)}>x</button>
+                  </li>
+                ))}
+              </ul>
+              <input
+                aria-label="New tag"
+                value={newTag}
+                onChange={e => setNewTag(e.target.value)}
+              />
+              <button onClick={addTag}>Add Tag</button>
+            </div>
+            <button
+              onClick={() => {
+                const blob = new Blob([JSON.stringify(dataset, null, 2)], {
+                  type: 'application/json'
+                });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `${dataset.name}.json`;
+                a.click();
+              }}
+            >
+              Download Metadata
+            </button>
+          </div>
+        )}
+        {tab === 'Permissions' && (
+          <div>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Role</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dataset.acls.map((a, i) => (
+                  <tr key={i}>
+                    <td>{a.user}</td>
+                    <td>{a.role}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div style={{ marginTop: '0.5rem' }}>
+              <input
+                placeholder="user@example.com"
+                value={acl.user}
+                onChange={e => setAcl({ ...acl, user: e.target.value })}
+                aria-label="ACL user"
+              />
+              <input
+                placeholder="role"
+                value={acl.role}
+                onChange={e => setAcl({ ...acl, role: e.target.value })}
+                aria-label="ACL role"
+              />
+              <button onClick={addAcl}>Add</button>
+            </div>
+          </div>
+        )}
+        {tab === 'Lineage' && (
+          <div>
+            <p>Upstream: {dataset.lineage.upstream.join(', ')}</p>
+            <p>Downstream: {dataset.lineage.downstream.join(', ')}</p>
+          </div>
+        )}
+        {tab === 'Usage' && (
+          <div>
+            <p>Access count: {dataset.accessCount}</p>
+            <p>Last queried: {dataset.lastQueried}</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/services/datasetService.ts
+++ b/src/services/datasetService.ts
@@ -1,18 +1,84 @@
+export interface AclEntry {
+  user: string;
+  role: string;
+}
+
+export interface Lineage {
+  upstream: string[];
+  downstream: string[];
+}
+
 export interface Dataset {
   id: number;
   name: string;
+  description: string;
   tags: string[];
   status: 'published' | 'private';
   owner: string;
   useCases: string[];
+  acls: AclEntry[];
+  accessCount: number;
+  lastQueried: string;
+  lineage: Lineage;
 }
 
-const datasets: Dataset[] = [
-  { id: 1, name: 'Payments', tags: ['finance', 'transactions'], status: 'published', owner: 'Team Alpha', useCases: ['analytics'] },
-  { id: 2, name: 'Customer360', tags: ['customer', 'profile'], status: 'private', owner: 'Team Beta', useCases: ['marketing'] },
-  { id: 3, name: 'Trades', tags: ['markets'], status: 'published', owner: 'Team Gamma', useCases: ['risk', 'reporting'] },
+let datasets: Dataset[] = [
+  {
+    id: 1,
+    name: 'Payments',
+    description: 'Transactions across all payment channels',
+    tags: ['finance', 'transactions'],
+    status: 'published',
+    owner: 'Team Alpha',
+    useCases: ['analytics'],
+    acls: [
+      { user: 'alice@example.com', role: 'reader' },
+      { user: 'bob@example.com', role: 'writer' }
+    ],
+    accessCount: 1234,
+    lastQueried: '2024-05-01',
+    lineage: { upstream: ['RawPayments'], downstream: ['PaymentAnalytics'] }
+  },
+  {
+    id: 2,
+    name: 'Customer360',
+    description: 'Unified customer profile',
+    tags: ['customer', 'profile'],
+    status: 'private',
+    owner: 'Team Beta',
+    useCases: ['marketing'],
+    acls: [{ user: 'carol@example.com', role: 'owner' }],
+    accessCount: 523,
+    lastQueried: '2024-04-15',
+    lineage: { upstream: ['CRM'], downstream: ['CampaignTool'] }
+  },
+  {
+    id: 3,
+    name: 'Trades',
+    description: 'Trade records for all desks',
+    tags: ['markets'],
+    status: 'published',
+    owner: 'Team Gamma',
+    useCases: ['risk', 'reporting'],
+    acls: [{ user: 'dave@example.com', role: 'reader' }],
+    accessCount: 812,
+    lastQueried: '2024-05-10',
+    lineage: { upstream: ['RawTrades'], downstream: ['TradeReports'] }
+  }
 ];
 
 export const fetchDatasets = async (): Promise<Dataset[]> => {
-  return new Promise(resolve => setTimeout(() => resolve(datasets), 300));
+  return new Promise(resolve => setTimeout(() => resolve([...datasets]), 200));
+};
+
+export const fetchDatasetById = async (id: number): Promise<Dataset | undefined> => {
+  const all = await fetchDatasets();
+  return all.find(d => d.id === id);
+};
+
+export const updateDataset = async (id: number, update: Partial<Dataset>): Promise<Dataset> => {
+  const index = datasets.findIndex(d => d.id === id);
+  if (index === -1) throw new Error('Dataset not found');
+  datasets[index] = { ...datasets[index], ...update };
+  return datasets[index];
 };


### PR DESCRIPTION
## Summary
- enrich dataset service with description, lineage, usage metrics and ACL storage
- allow editing visibility, tags and ACLs within dataset detail view
- cover dataset detail interactions with a new Jest test and add project .gitignore

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08627f53c8324af6b5882bbae2b17